### PR TITLE
Extend HSV indexing of lstg.Color

### DIFF
--- a/LuaSTG/LuaSTG/LuaBinding/LW_Color.cpp
+++ b/LuaSTG/LuaSTG/LuaBinding/LW_Color.cpp
@@ -148,6 +148,7 @@ namespace LuaSTGPlus::LuaWrapper
 			{
 				GETUDATA(p, 1);
 				const char* key = luaL_checkstring(L, 2);
+				Core::Vector4F hsva = RGB2HSV(p->r, p->g, p->b, p->a);
 				switch (LuaSTG::MapColorMember(key))
 				{
 				case LuaSTG::ColorMember::m_a:
@@ -163,17 +164,14 @@ namespace LuaSTGPlus::LuaWrapper
 					p->b = (fByte)std::clamp<fInt>(luaL_checkinteger(L, 3), 0, 255);
 					break;
 				case LuaSTG::ColorMember::m_h:
-					Core::Vector4F hsva = RGB2HSV(p->r, p->g, p->b, p->a);
 					hsva.x = (float)std::clamp(luaL_checknumber(L, 3), 0.0, 100.0);
 					*p = HSV2RGB(hsva.x, hsva.y, hsva.z, hsva.w);
 					break;
 				case LuaSTG::ColorMember::m_s:
-					Core::Vector4F hsva = RGB2HSV(p->r, p->g, p->b, p->a);
 					hsva.y = (float)std::clamp(luaL_checknumber(L, 3), 0.0, 100.0);
 					*p = HSV2RGB(hsva.x, hsva.y, hsva.z, hsva.w);
 					break;
 				case LuaSTG::ColorMember::m_v:
-					Core::Vector4F hsva = RGB2HSV(p->r, p->g, p->b, p->a);
 					hsva.z = (float)std::clamp(luaL_checknumber(L, 3), 0.0, 100.0);
 					*p = HSV2RGB(hsva.x, hsva.y, hsva.z, hsva.w);
 					break;

--- a/LuaSTG/LuaSTG/LuaBinding/LW_Color.cpp
+++ b/LuaSTG/LuaSTG/LuaBinding/LW_Color.cpp
@@ -44,7 +44,7 @@ namespace LuaSTGPlus::LuaWrapper
 	{
 		struct Function
 		{
-#define GETUDATA(p, i) Core::Color4B* (p) = Cast(L, i);
+		#define GETUDATA(p, i) Core::Color4B* (p) = Cast(L, i);
 
 			static int ARGB(lua_State* L) noexcept
 			{
@@ -370,7 +370,7 @@ namespace LuaSTGPlus::LuaWrapper
 				return 1;
 			}
 
-#undef GETUDATA
+		#undef GETUDATA
 		};
 
 		luaL_Reg tMethods[] = {


### PR DESCRIPTION
I decided to make it so you could index colors via HSV (get and set), thought it might be useful for some use cases.

I also changed the `lstg.Color:AHSV()` function to return the AHSV values, like `lstg.Color:ARGB()`.

In the future I might like to add these features to the advanced game object class (render object), so that users can control HSV through _h/_s/_v as well. This would be very useful for coloring bullets and lasers and such.