### PR TITLE
Borderless Fullscreen Implementation

### DIFF
--- a/LuaSTG/Core/Graphics/Window.hpp
+++ b/LuaSTG/Core/Graphics/Window.hpp
@@ -95,7 +95,8 @@ namespace Core::Graphics
 		virtual float getDPIScaling() = 0;
 
 		virtual void setWindowMode(Vector2U size) = 0;
-		virtual void setFullScreenMode() = 0;
+		virtual void setExclusiveFullScreenMode() = 0;
+		virtual void setBorderlessFullScreenMode() = 0;
 
 		virtual uint32_t getMonitorCount() = 0;
 		virtual RectI getMonitorRect(uint32_t index) = 0;

--- a/LuaSTG/Core/Graphics/Window_Win32.hpp
+++ b/LuaSTG/Core/Graphics/Window_Win32.hpp
@@ -79,6 +79,7 @@ namespace Core::Graphics
 		bool recreateWindow();
 		void _toggleFullScreenMode();
 		void _setWindowMode(Vector2U size, bool ignore_size);
+		void _setBorderlessFullscreenMode();
 		void _setFullScreenMode();
 
 		void implSetApplicationModel(IApplicationModel* p_framework) { m_framework = p_framework; }
@@ -137,7 +138,8 @@ namespace Core::Graphics
 		float getDPIScaling();
 
 		void setWindowMode(Vector2U size);
-		void setFullScreenMode();
+		void setExclusiveFullScreenMode();
+		void setBorderlessFullScreenMode();
 
 		uint32_t getMonitorCount();
 		RectI getMonitorRect(uint32_t index);

--- a/LuaSTG/LuaSTG/AppFrame.h
+++ b/LuaSTG/LuaSTG/AppFrame.h
@@ -169,10 +169,12 @@ namespace LuaSTGPlus
 
 		// 以窗口模式显示  
 		// 当 monitor_rect 为空矩形时，窗口自动挑选最近的显示器来居中，否则根据显示器矩形选择匹配的显示器居中  
-		bool SetDisplayModeWindow(Core::Vector2U window_size, bool vsync, Core::RectI monitor_rect, bool borderless);
+		// bool SetDisplayModeWindow(Core::Vector2U window_size, bool vsync, Core::RectI monitor_rect, bool borderless);
+		bool SetDisplayModeWindow(Core::Vector2U window_size, bool vsync, uint32_t monitor_idx, bool borderless);
 
 		// 以全屏无边框窗口显示  
-		bool SetDisplayModeFullscreen(Core::RectI monitor_rect, bool vsync);
+		// bool SetDisplayModeFullscreen(Core::RectI monitor_rect, bool vsync);
+		bool SetDisplayModeBorderlessFullscreen(Core::Vector2U window_size, uint32_t monitor_idx, bool vsync);
 
 		// 以独占全屏显示  
 		// 当 refresh_rate 为全 0 时，自动选择合适的匹配的刷新率  

--- a/LuaSTG/LuaSTG/AppFrameDisplayMode.cpp
+++ b/LuaSTG/LuaSTG/AppFrameDisplayMode.cpp
@@ -75,7 +75,37 @@ namespace LuaSTGPlus
 			spdlog::error("[luastg] 显示模式切换失败：{} -> {}", getFullscreenTypeString(from_mode), to_mode);
 	}
 
-	bool AppFrame::SetDisplayModeWindow(Core::Vector2U window_size, bool vsync, Core::RectI monitor_rect, bool borderless)
+	// bool AppFrame::SetDisplayModeWindow(Core::Vector2U window_size, bool vsync, Core::RectI monitor_rect, bool borderless)
+	// {
+	// 	auto* window = GetAppModel()->getWindow();
+	// 	auto* swapchain = GetAppModel()->getSwapChain();
+
+	// 	swapchain->setVSync(vsync);
+	// 	bool const result = swapchain->setCanvasSize(window_size);
+
+	// 	window->setWindowMode(window_size);
+	// 	if (!isRectEmpty(monitor_rect))
+	// 	{
+	// 		bool find_result = false;
+	// 		uint32_t const index = matchMonitorIndex(window, monitor_rect, find_result);
+	// 		std::ignore = find_result; // 对于窗口模式，即使找不到对应的显示器用于居中也无所谓
+	// 		window->setMonitorCentered(index);
+	// 	}
+	// 	if (!borderless)
+	// 	{
+	// 		window->setNativeIcon((void*)(ptrdiff_t)IDI_APPICON);
+	// 	}
+		
+	// 	logResult(result, m_Setting, MODE_NAME_WINDOW);
+
+	// 	m_Setting.canvas_size = window_size;
+	// 	m_Setting.fullscreen = false;
+	// 	m_Setting.vsync = vsync;
+		
+	// 	return result;
+	// }
+
+	bool AppFrame::SetDisplayModeWindow(Core::Vector2U window_size, bool vsync, uint32_t monitor_idx, bool borderless)
 	{
 		auto* window = GetAppModel()->getWindow();
 		auto* swapchain = GetAppModel()->getSwapChain();
@@ -84,13 +114,14 @@ namespace LuaSTGPlus
 		bool const result = swapchain->setCanvasSize(window_size);
 
 		window->setWindowMode(window_size);
-		if (!isRectEmpty(monitor_rect))
-		{
-			bool find_result = false;
-			uint32_t const index = matchMonitorIndex(window, monitor_rect, find_result);
-			std::ignore = find_result; // 对于窗口模式，即使找不到对应的显示器用于居中也无所谓
-			window->setMonitorCentered(index);
-		}
+		// if (!isRectEmpty(monitor_rect))
+		// {
+		// 	bool find_result = false;
+		// 	uint32_t const index = matchMonitorIndex(window, monitor_rect, find_result);
+		// 	std::ignore = find_result; // 对于窗口模式，即使找不到对应的显示器用于居中也无所谓
+		// 	window->setMonitorCentered(index);
+		// }
+		window->setMonitorCentered(monitor_idx);
 		if (!borderless)
 		{
 			window->setNativeIcon((void*)(ptrdiff_t)IDI_APPICON);
@@ -105,39 +136,78 @@ namespace LuaSTGPlus
 		return result;
 	}
 
-	bool AppFrame::SetDisplayModeFullscreen(Core::RectI monitor_rect, bool vsync)
+	// bool AppFrame::SetDisplayModeFullscreen(Core::RectI monitor_rect, bool vsync)
+	// {
+	// 	auto* window = GetAppModel()->getWindow();
+	// 	auto* swapchain = GetAppModel()->getSwapChain();
+
+	// 	if (isRectEmpty(monitor_rect))
+	// 	{
+	// 		// 对于全屏无边框窗口模式，显示器矩形为空，将会失败
+	// 		logResult(false, m_Setting, MODE_NAME_FULLSCREEN);
+	// 		return false;
+	// 	}
+
+	// 	bool find_result = false;
+	// 	uint32_t const index = matchMonitorIndex(window, monitor_rect, find_result);
+	// 	if (!find_result)
+	// 	{
+	// 		// 对于全屏无边框窗口模式，如果找不到对应的显示器，将会失败
+	// 		logResult(find_result, m_Setting, MODE_NAME_FULLSCREEN);
+	// 		return false;
+	// 	}
+	// 	Core::Vector2I const window_size = getMonitorSize(window, index);
+
+	// 	auto const size = Core::Vector2U(uint32_t(window_size.x), uint32_t(window_size.y));
+
+	// 	swapchain->setVSync(vsync);
+	// 	bool const result = swapchain->setCanvasSize(size);
+
+	// 	window->setFullScreenMode();
+	// 	window->setMonitorFullScreen(index);
+
+	// 	logResult(result, m_Setting, MODE_NAME_FULLSCREEN);
+
+	// 	m_Setting.canvas_size = size;
+	// 	m_Setting.fullscreen = true;
+	// 	m_Setting.vsync = vsync;
+		
+	// 	return result;
+	// }
+
+	bool AppFrame::SetDisplayModeBorderlessFullscreen(Core::Vector2U window_size, uint32_t monitor_idx, bool vsync)
 	{
 		auto* window = GetAppModel()->getWindow();
 		auto* swapchain = GetAppModel()->getSwapChain();
 
-		if (isRectEmpty(monitor_rect))
-		{
-			// 对于全屏无边框窗口模式，显示器矩形为空，将会失败
-			logResult(false, m_Setting, MODE_NAME_FULLSCREEN);
-			return false;
-		}
+		// if (isRectEmpty(monitor_rect))
+		// {
+		// 	// 对于全屏无边框窗口模式，显示器矩形为空，将会失败
+		// 	logResult(false, m_Setting, MODE_NAME_FULLSCREEN);
+		// 	return false;
+		// }
 
-		bool find_result = false;
-		uint32_t const index = matchMonitorIndex(window, monitor_rect, find_result);
-		if (!find_result)
-		{
-			// 对于全屏无边框窗口模式，如果找不到对应的显示器，将会失败
-			logResult(find_result, m_Setting, MODE_NAME_FULLSCREEN);
-			return false;
-		}
-		Core::Vector2I const window_size = getMonitorSize(window, index);
+		// bool find_result = false;
+		// uint32_t const index = matchMonitorIndex(window, monitor_rect, find_result);
+		// if (!find_result)
+		// {
+		// 	// 对于全屏无边框窗口模式，如果找不到对应的显示器，将会失败
+		// 	logResult(find_result, m_Setting, MODE_NAME_FULLSCREEN);
+		// 	return false;
+		// }
+		Core::Vector2I const monitor_size = getMonitorSize(window, monitor_idx);
 
-		auto const size = Core::Vector2U(uint32_t(window_size.x), uint32_t(window_size.y));
+		// auto const size = Core::Vector2U(uint32_t(window_size.x), uint32_t(window_size.y));
 
 		swapchain->setVSync(vsync);
-		bool const result = swapchain->setCanvasSize(size);
+		bool const result = swapchain->setCanvasSize(window_size);
 
-		window->setFullScreenMode();
-		window->setMonitorFullScreen(index);
+		window->setBorderlessFullScreenMode();
+		window->setMonitorFullScreen(monitor_idx);
 
 		logResult(result, m_Setting, MODE_NAME_FULLSCREEN);
 
-		m_Setting.canvas_size = size;
+		m_Setting.canvas_size = window_size;
 		m_Setting.fullscreen = true;
 		m_Setting.vsync = vsync;
 		
@@ -154,7 +224,7 @@ namespace LuaSTGPlus
 		bool const result = swapchain->setCanvasSize(window_size);
 
 		window->setWindowMode(window_size);
-		window->setFullScreenMode();
+		window->setExclusiveFullScreenMode();
 
 		logResult(result, m_Setting, MODE_NAME_FULLSCREEN);
 
@@ -176,7 +246,8 @@ namespace LuaSTGPlus
 			return SetDisplayModeWindow(
 				m_Setting.canvas_size,
 				m_Setting.vsync,
-				Core::RectI(),
+				// Core::RectI(),
+				0,
 				false);
 	}
 

--- a/LuaSTG/LuaSTG/LuaBinding/LW_LuaSTG.cpp
+++ b/LuaSTG/LuaSTG/LuaBinding/LW_LuaSTG.cpp
@@ -118,7 +118,7 @@ void LuaSTGPlus::BuiltInFunctionWrapper::Register(lua_State* L)noexcept
 
 			if (windowed)
 			{
-				bool const result = LAPP.SetDisplayModeWindow(size, vsync, Core::RectI(), false);
+				bool const result = LAPP.SetDisplayModeWindow(size, vsync, 0, false);
 				lua_pushboolean(L, result);
 			}
 			else
@@ -126,6 +126,47 @@ void LuaSTGPlus::BuiltInFunctionWrapper::Register(lua_State* L)noexcept
 				bool const result = LAPP.SetDisplayModeExclusiveFullscreen(size, vsync, Core::Rational());
 				lua_pushboolean(L, result);
 			}
+
+			return 1;
+		}
+		static int VideoModeWindowed(lua_State* L)noexcept
+		{
+			uint32_t const width = (uint32_t)luaL_checkinteger(L, 1);
+			uint32_t const height = (uint32_t)luaL_checkinteger(L, 2);
+			bool const vsync = lua_toboolean(L, 3);
+			uint32_t const monitor = (uint32_t)luaL_optinteger(L, 4, 0);
+
+			auto const size = Core::Vector2U(width, height);
+
+			bool const result = LAPP.SetDisplayModeWindow(size, vsync, monitor, false);
+			lua_pushboolean(L, result);
+
+			return 1;
+		}
+		static int VideoModeFSExclusive(lua_State* L)noexcept
+		{
+			uint32_t const width = (uint32_t)luaL_checkinteger(L, 1);
+			uint32_t const height = (uint32_t)luaL_checkinteger(L, 2);
+			bool const vsync = lua_toboolean(L, 3);
+
+			auto const size = Core::Vector2U(width, height);
+
+			bool const result = LAPP.SetDisplayModeExclusiveFullscreen(size, vsync, 60);
+			lua_pushboolean(L, result);
+
+			return 1;
+		}
+		static int VideoModeFSBorderless(lua_State* L)noexcept
+		{
+			uint32_t const width = (uint32_t)luaL_checkinteger(L, 1);
+			uint32_t const height = (uint32_t)luaL_checkinteger(L, 2);
+			bool const vsync = lua_toboolean(L, 3);
+			uint32_t const monitor = (uint32_t)luaL_optinteger(L, 4, 0);
+
+			auto const size = Core::Vector2U(width, height);
+
+			bool const result = LAPP.SetDisplayModeBorderlessFullscreen(size, monitor, vsync);
+			lua_pushboolean(L, result);
 
 			return 1;
 		}
@@ -225,6 +266,9 @@ void LuaSTGPlus::BuiltInFunctionWrapper::Register(lua_State* L)noexcept
 		
 		#pragma region 窗口与交换链控制函数
 		{ "ChangeVideoMode", &WrapperImplement::ChangeVideoMode },
+		{ "VideoModeWindowed", &WrapperImplement::VideoModeWindowed },
+		{ "VideoModeFSExclusive", &WrapperImplement::VideoModeFSExclusive },
+		{ "VideoModeFSBorderless", &WrapperImplement::VideoModeFSBorderless },
 		{ "EnumResolutions", &WrapperImplement::EnumResolutions },
 		{ "EnumGPUs", &WrapperImplement::EnumGPUs },
 		{ "ChangeGPU", &WrapperImplement::ChangeGPU },


### PR DESCRIPTION
Added new API for changing window mode:
```lua
-- int, int, bool, int
lstg.VideoModeWindowed(width, height, vsync, monitor_index)
-- int, int, bool
lstg.VideoModeFSExclusive(width, height, vsync)
-- int, int, bool, int
lstg.VideoModeFSBorderless(width, height, vsync, monitor_index)
```
Note that system monitor indexes will not always be in the same as the order used by LuaSTG. Perhaps that could be looked into?

`lstg.ChangeVideoMode()` has stayed compatible with older revisions (I saw there were changes made a while back, but they were reverted at some point).