### PR TITLE
Tracy 0.13.1 + Fixed major memory issue

### DIFF
--- a/cmake/import/tracy.cmake
+++ b/cmake/import/tracy.cmake
@@ -2,7 +2,7 @@
 
 CPMAddPackage(
     NAME tracy
-    VERSION 0.12.2
+    VERSION 0.13.1
     GITHUB_REPOSITORY wolfpld/tracy
     DOWNLOAD_ONLY YES
 )
@@ -13,6 +13,7 @@ if(tracy_ADDED)
     if(LUASTG_LINK_TRACY_CLIENT)
         target_compile_definitions(tracy PUBLIC
             TRACY_ENABLE
+            TRACY_ON_DEMAND
         )
     endif()
     # WTF ???


### PR DESCRIPTION
Tracy, by defaults, keeps the data of the traces it has since the engine's startup, so it can display them a long time after the engine started and still have all the infos. However, this introduced a major issue where, when calling tracy zones and other functions a lot of time, would lead to major increase in memory usage and memory leaks, eventually leading to a crash.

Even without enabling tracy link, the calls to the macro were still present in the code, leading to the same issue in debug and release versions of LuaSTG-Sub. This is a minor issue in normal gameplay, but when starting to play with worlds and other more intensive functions, it becomes a major issue. With testing a intensive game, we went up to more 5Gb+ memory usage.

Enabling the `TRACY_ON_DEMAND` compile definition in `tracy.cmake` fixes the issue.
I also took the opportunity to upgrade to tracy 0.13.1 which is more stable.