### PR TITLE
lua binding: fix lua to cpp blend mode unknown value

### DIFF
--- a/LuaSTG/LuaSTG/GameResource/ResourceBase.hpp
+++ b/LuaSTG/LuaSTG/GameResource/ResourceBase.hpp
@@ -18,7 +18,7 @@ namespace luastg {
 
 	// 混合模式
 	enum class BlendMode : uint8_t {
-		__RESERVE__ = 0,
+		Unknown = 0,
 
 		MulAlpha = 1,		//顶点色和纹理色相乘 混合模式：正常（透明度混合）
 		MulAdd = 2,			//顶点色和纹理色相乘 混合模式：线性减淡（加法）
@@ -41,8 +41,6 @@ namespace luastg {
 		AddScreen = 17,		//顶点色和纹理色相加 混合模式：滤色（相加减去相乘）
 
 		One = 18,			//无混合，直接覆盖
-
-		_KEY_NOT_FOUND = 0x7f,
 	};
 	static_assert(sizeof(BlendMode) == sizeof(uint8_t));
 

--- a/LuaSTG/LuaSTG/LuaBinding/LuaWrapperMisc.hpp
+++ b/LuaSTG/LuaSTG/LuaBinding/LuaWrapperMisc.hpp
@@ -80,7 +80,7 @@ namespace luastg
 			return BlendMode::MulAlpha;
 		}
 		BlendMode mode = static_cast<BlendMode>(LuaSTG::MapBlendModeX(key, len));
-		if (mode == BlendMode::_KEY_NOT_FOUND) {
+		if (mode == BlendMode::Unknown) {
 			luaL_error(L, "invalid blend mode '%s'.", key);
 			return BlendMode::MulAlpha;
 		}


### PR DESCRIPTION
按理来说没有 `screen+add` 这种混合模式。

v0.20.16 会检测出来，但 0.21.x 的转换逻辑出问题。

<img width="256" height="635" alt="image" src="https://github.com/user-attachments/assets/58c60e93-1bef-4127-805f-d625bf6ef277" />


